### PR TITLE
Return all the words, not unique ones.

### DIFF
--- a/language_service/service/tag/chinese.py
+++ b/language_service/service/tag/chinese.py
@@ -6,9 +6,8 @@ parser = zh_core_web_sm.load()
 
 
 def tag_chinese(text):
-    unique_words = {
-        word.text: Word(token=word.text, tag=word.pos_, lemma=word.lemma_)
+    return [
+        Word(token=word.text, tag=word.pos_, lemma=word.lemma_)
         for word in parser(text)
         if is_not_punctuation(word.text)
-    }
-    return list(unique_words.values())
+    ]

--- a/language_service/service/tag/english.py
+++ b/language_service/service/tag/english.py
@@ -6,9 +6,8 @@ parser = en_core_web_sm.load()
 
 
 def tag_english(text):
-    unique_words = {
-        word.text: Word(token=word.text, tag=word.pos_, lemma=word.lemma_)
+    return [
+        Word(token=word.text, tag=word.pos_, lemma=word.lemma_)
         for word in parser(text)
         if is_not_punctuation(word.text)
-    }
-    return list(unique_words.values())
+    ]

--- a/language_service/service/tag/spanish.py
+++ b/language_service/service/tag/spanish.py
@@ -6,9 +6,8 @@ parser = es_core_news_sm.load()
 
 
 def tag_spanish(text):
-    unique_words = {
-        word.text: Word(token=word.text, tag=word.pos_, lemma=word.lemma_)
+    return [
+        Word(token=word.text, tag=word.pos_, lemma=word.lemma_)
         for word in parser(text)
         if is_not_punctuation(word.text)
-    }
-    return list(unique_words.values())
+    ]

--- a/tests/service/tag/test_tagging.py
+++ b/tests/service/tag/test_tagging.py
@@ -21,56 +21,6 @@ def test_can_tag_chinese():
     )
 
 
-def test_chinese_tagging_no_duplicates():
-    words = tag(
-        "CHINESE",
-        "石室诗士施氏，嗜狮，誓食十狮。氏时时适市视狮。十时，适十狮适市。 是时，适施氏适市。氏视是十狮，恃矢势，使是十狮逝世。氏拾是十狮尸，适石室。石室湿，氏使侍拭石室。石室拭，氏始试食是十狮尸。食时，始识是十狮，实十石狮尸。试释是事。",
-    )
-    compare(
-        words,
-        [
-            Word(token="石室", tag="PROPN", lemma="石室"),
-            Word(token="诗士", tag="NOUN", lemma="诗士"),
-            Word(token="施氏", tag="VERB", lemma="施氏"),
-            Word(token="嗜狮", tag="NOUN", lemma="嗜狮"),
-            Word(token="誓食", tag="VERB", lemma="誓食"),
-            Word(token="十狮", tag="NUM", lemma="十狮"),
-            Word(token="氏时", tag="NOUN", lemma="氏时"),
-            Word(token="时适市", tag="NOUN", lemma="时适市"),
-            Word(token="视狮", tag="VERB", lemma="视狮"),
-            Word(token="十时", tag="NUM", lemma="十时"),
-            Word(token="适", tag="VERB", lemma="适"),
-            Word(token="十", tag="NUM", lemma="十"),
-            Word(token="狮", tag="NUM", lemma="狮"),
-            Word(token="适市", tag="VERB", lemma="适市"),
-            Word(token="是时", tag="VERB", lemma="是时"),
-            Word(token="适施", tag="VERB", lemma="适施"),
-            Word(token="氏", tag="NOUN", lemma="氏"),
-            Word(token="氏视", tag="PROPN", lemma="氏视"),
-            Word(token="是", tag="VERB", lemma="是"),
-            Word(token="恃", tag="NOUN", lemma="恃"),
-            Word(token="矢势", tag="VERB", lemma="矢势"),
-            Word(token="使", tag="VERB", lemma="使"),
-            Word(token="逝世", tag="NOUN", lemma="逝世"),
-            Word(token="氏拾", tag="ADV", lemma="氏拾"),
-            Word(token="狮尸", tag="VERB", lemma="狮尸"),
-            Word(token="适石室", tag="VERB", lemma="适石室"),
-            Word(token="湿", tag="NOUN", lemma="湿"),
-            Word(token="氏使", tag="NOUN", lemma="氏使"),
-            Word(token="侍拭", tag="NOUN", lemma="侍拭"),
-            Word(token="拭", tag="VERB", lemma="拭"),
-            Word(token="氏始", tag="ADV", lemma="氏始"),
-            Word(token="试食", tag="VERB", lemma="试食"),
-            Word(token="食时", tag="NOUN", lemma="食时"),
-            Word(token="始识", tag="NOUN", lemma="始识"),
-            Word(token="实十", tag="ADJ", lemma="实十"),
-            Word(token="石", tag="ADV", lemma="石"),
-            Word(token="试释", tag="NOUN", lemma="试释"),
-            Word(token="事", tag="NOUN", lemma="事"),
-        ],
-    )
-
-
 def test_can_tag_english():
     words = tag("ENGLISH", "The test has passed because these words were returned.")
     compare(
@@ -85,30 +35,6 @@ def test_can_tag_english():
             Word(token="words", tag="NOUN", lemma="word"),
             Word(token="were", tag="AUX", lemma="be"),
             Word(token="returned", tag="VERB", lemma="return"),
-        ],
-    )
-
-
-def test_english_tagging_no_duplicates():
-    words = tag(
-        "ENGLISH", "This is the song that never ends, it goes on and on my friends"
-    )
-    compare(
-        words,
-        [
-            Word(token="This", tag="DET", lemma="this"),
-            Word(token="is", tag="AUX", lemma="be"),
-            Word(token="the", tag="DET", lemma="the"),
-            Word(token="song", tag="NOUN", lemma="song"),
-            Word(token="that", tag="DET", lemma="that"),
-            Word(token="never", tag="ADV", lemma="never"),
-            Word(token="ends", tag="VERB", lemma="end"),
-            Word(token="it", tag="PRON", lemma="-PRON-"),
-            Word(token="goes", tag="VERB", lemma="go"),
-            Word(token="on", tag="ADP", lemma="on"),
-            Word(token="and", tag="CCONJ", lemma="and"),
-            Word(token="my", tag="DET", lemma="-PRON-"),
-            Word(token="friends", tag="NOUN", lemma="friend"),
         ],
     )
 
@@ -129,19 +55,6 @@ def test_can_tag_spanish():
             Word(token="palabras", tag="NOUN", lemma="palabra"),
             Word(token="fueron", tag="VERB", lemma="ser"),
             Word(token="devueltas", tag="VERB", lemma="devolver"),
-        ],
-    )
-
-
-def test_spanish_tagging_no_duplicates():
-    words = tag("SPANISH", "Hola, mi llamo Lucas. Hola Lucas")
-    compare(
-        words,
-        [
-            Word(token="Hola", tag="PROPN", lemma="Hola"),
-            Word(token="mi", tag="DET", lemma="mi"),
-            Word(token="llamo", tag="NOUN", lemma="llamar"),
-            Word(token="Lucas", tag="PROPN", lemma="Lucas"),
         ],
     )
 


### PR DESCRIPTION
Words should be returned as they occur in the text, not filtered by uniqueness. 

Why? Two reasons:
- Choosing what to display is a user experience concern, and is best handled there. That means API or the clients. 
- Users get confused if their words just disappear.

Historically the definitions and tagging were coupled together, so it made sense to reduce data transfer from an engineering perspective. It's the opposite from a user experience perspective. 