### PR TITLE
Upgrade GitHub actions versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: brpaz/hadolint-action@v1.3.1
+    - uses: brpaz/hadolint-action@v1.5.0
       name: Lint container image
       with:
         dockerfile: Dockerfile


### PR DESCRIPTION
Upgrade all the github actions versions in one spot to not build too many release versions.